### PR TITLE
Use `fsw` on OS X for file system watching

### DIFF
--- a/tagwatch
+++ b/tagwatch
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-EXCLUDE_GLOB_DEFAULT="*/tags.*;*/log/*;*/tmp/*;*/.git/*;*/coverage/*;*/doc/*;*/public/*"
+EXCLUDE_REGEX_DEFAULT="tags.*|log/|tmp/|\.git/|coverage/|doc/|public/"
 SCRIPTNAME=`basename $0`
 CTAGS_DEFAULT_OPTIONS="-R --exclude=*.js --langmap=ruby:+.rake.builder.rjs --languages=-javascript"
 
@@ -9,21 +9,18 @@ help() {
 
 ABOUT:
 
-  $SCRIPTNAME - Auto updates ctags files via kernel-level filesystem events.
+  $SCRIPTNAME - Auto updates ctags files via filesystem events.
 
 $SCRIPTNAME watches a directory recursively for file changes and automatically
 updates your exuberant-ctags "tags" file.
 
-It subscribes to filesystem events via python's watchmedo and should impose very
-little overhead. It is aware of file changes spawned by anything - your editor,
-your source control system, etc. It will not update more than once a second.
+It subscribes to filesystem events via inotifywait on linux, and fsw on OS X,
+and should impose very little overhead. It is aware of file changes spawned by
+anything - your editor, your source control system, etc. It will not update
+more than once a second.
 
-LINUX:
-It requires exuberant-ctags and watchmedo. Install "exuberant-ctags" and run
-"pip install watchmedo" on modern debian-derived systems.
-
-OS X:
-FIXME
+It requires exuberant-ctags and inotifywait. Install "exuberant-ctags" and
+"inotify-tools" on modern debian-derived systems.
 
 OPTIONS:
 
@@ -32,8 +29,8 @@ OPTIONS:
       occurred too quickly after the last update.
   -d: the directory to watch (the "tags" file is written here too).
       Defaults to pwd
-  -e: A shell glob pattern that defines what files / directories to ignore.
-      Defaults to: "$EXCLUDE_GLOB_DEFAULT"
+  -e: An extended POSIX regex that defines what files / directories to ignore.
+      Defaults to: "$EXCLUDE_REGEX_DEFAULT"
   -c: Options passed to the exuberant-ctags command, the defaults are fairly
       rails specific.
       Defaults to: "$CTAGS_DEFAULT_OPTIONS"
@@ -41,10 +38,12 @@ OPTIONS:
 RC Configuration:
 
 Files in the watched_directory named ".tagwatch.rc" are sourced and allow you
-to configure default options. Currently, you can configure -e and -c.
+to configure default options. Currently, you can configured -e (the regex that
+defines which updated files / paths to ignore) and -c (the default ctags
+options).
 
   # ./.tagwatch.rc
-  EXCLUDE_GLOB="*/tags.*;*/log/*;*/tmp/*;*/.git/*;*/coverage/*;*/doc/*"
+  EXCLUDE_REGEX="tags.*|log/|tmp/|\.git/|coverage/|doc"
   CTAGS_DEFAULT_OPTIONS="-R --exclude='*.js' --langmap='ruby:+.rake.builder.rjs' --languages=-javascript"
 
 USAGE:
@@ -75,7 +74,7 @@ while getopts "hvd:e:c:" opt; do
     h) help ;;
     v) VERBOSE=1 ;;
     d) WATCHED_DIR=$OPTARG ;;
-    e) EXCLUDE_GLOB=$OPTARG ;;
+    e) EXCLUDE_REGEX=$OPTARG ;;
     c) CTAGS_OPTIONS=$OPTARG ;;
   esac
 done
@@ -85,18 +84,23 @@ source_rc_optionally $WATCHED_DIR
 
 VERBOSE=${VERBOSE:-0}
 
-EXCLUDE_GLOB=${EXCLUDE_GLOB:-$EXCLUDE_GLOB_DEFAULT}
+EXCLUDE_REGEX=${EXCLUDE_REGEX:-$EXCLUDE_REGEX_DEFAULT}
 CTAGS_OPTIONS=${CTAGS_OPTIONS:-$CTAGS_DEFAULT_OPTIONS}
 
 TIME_COMMAND="date +%s"
 PREVIOUS_RUN_TIME=`$TIME_COMMAND`
 
-log_if_verbose "EXCLUDE_GLOB: $EXCLUDE_GLOB\n"
+log_if_verbose "EXCLUDE_REGEX: $EXCLUDE_REGEX\n"
 log_if_verbose "CTAGS_OPTIONS: $CTAGS_OPTIONS\n"
 log_if_verbose "Watching: $WATCHED_DIR, PID: $$\n"
 
 watch_command(){
-  watchmedo shell-command --recursive --ignore-pattern="$EXCLUDE_GLOB" $WATCHED_DIR
+  if [ "$OSTYPE" = "linux-gnu" ]; then
+    inotifywait -q --excludei="$EXCLUDE_REGEX"\
+      -m -r -e modify -e move -e create -e delete $WATCHED_DIR
+  else
+    fsw --recursive --latency 0.1 --extended --exclude="$EXCLUDE_REGEX" $WATCHED_DIR
+  fi
 }
 
 watch_command | while read line; do


### PR DESCRIPTION
[fsw](https://github.com/emcrisostomo/fsw) is a minimal wrapper around a few different file system notifications. In this case we are using it to wrap the OS X File System Events API.

This greatly simplifies install as `fsw` is a brew installable dependency. On linux, we can continue with `inotify` or we could also use `fsw` on linux as it justs wraps `inotify`.
